### PR TITLE
Enums

### DIFF
--- a/enums.lua
+++ b/enums.lua
@@ -1,0 +1,75 @@
+Resources = {
+	-- Raw
+	COAL             = "coal",
+	STONE            = "stone",
+	-- Ore
+	IRON             = "iron",
+	COPPER           = "copper",
+	LEAD             = "lead",
+	TITANIUM         = "titanium",
+	ZINC             = "zinc",
+	NICKEL           = "nickel",
+	STEEL            = "steel",
+	BRASS            = "brass",
+	INVAR            = "invar",
+	GALVANIZED_STEEL = "galvanized-steel"
+}
+
+Stock = {
+	PLATE     = "plate",
+	SHEET     = "sheet",
+	SQUARE    = "square",
+	ANGLE     = "angle",
+	GIRDER    = "girder",
+	WIRE      = "wire",
+	GEAR      = "gear",
+	FINE_GEAR = "fine-gear",
+	PIPE      = "pipe",
+	FINE_PIPE = "fine-pipe"
+}
+
+Machined_Part = {
+	PANELING       = "paneling",
+	LARGE_PANELING = "large-paneling",
+	FRAMING        = "framing",
+	GIRDERING      = "girdering",
+	GEARING        = "gearing",
+	FINE_GEARING   = "fine-gearing",
+	PIPING         = "piping",
+	FINE_PIPING    = "fine-piping",
+	WIRING         = "wiring",
+	SHIELDING      = "shielding",
+	SHAFTING       = "shafting",
+	BOLTS          = "bolts",
+	RIVETS         = "rivets"
+}
+
+Machined_Part_Property = {
+	BASIC                   = "basic",
+	LOAD_BEARING            = "load-bearing",
+	ELECTRICALLY_CONDUCTIVE = "electrically-conductive",
+	HIGH_TENSILE            = "high-tensile",
+	CORROSION_RESISTANT     = "corrosion-resistant",
+	LIGHTWEIGHT             = "lightweight",
+	DUCTILE                 = "ductile",
+	THERMALLY_STABLE        = "thermally-stable",
+	THERMALLY_CONDUCTIVE    = "thermally-conductive",
+	RADIATION_RESISTANT     = "radiation-resistant",
+	VERY_HIGH_TENSILE       = "very-high-tensile",
+	HEAVY_LOAD_BEARING      = "heavy-load-bearing",
+	HIGH_MELTING_POINT      = "high-melting-point"
+}
+
+Minisembler = {
+	WELDER         = "welder",
+	DRILL_PRESS    = "drill-press",
+	GRINDER        = "grinder",
+	METAL_BANDSAW  = "metal-bandsaw",
+	METAL_EXTRUDER = "metal-extruder",
+	MILL           = "mill",
+	METAL_LATHE    = "metal-lathe",
+	THREADER       = "threader",
+	SPOOLER        = "spooler",
+	ROLLER         = "roller",
+	BENDER         = "bender"
+}

--- a/enums.lua
+++ b/enums.lua
@@ -1,75 +1,77 @@
-Resources = {
-	-- Raw
-	COAL             = "coal",
-	STONE            = "stone",
-	-- Ore
-	IRON             = "iron",
-	COPPER           = "copper",
-	LEAD             = "lead",
-	TITANIUM         = "titanium",
-	ZINC             = "zinc",
-	NICKEL           = "nickel",
-	STEEL            = "steel",
-	BRASS            = "brass",
-	INVAR            = "invar",
-	GALVANIZED_STEEL = "galvanized-steel"
-}
+return {
+	Resources = {
+		-- Raw
+		COAL             = "coal",
+		STONE            = "stone",
+		-- Ore
+		IRON             = "iron",
+		COPPER           = "copper",
+		LEAD             = "lead",
+		TITANIUM         = "titanium",
+		ZINC             = "zinc",
+		NICKEL           = "nickel",
+		STEEL            = "steel",
+		BRASS            = "brass",
+		INVAR            = "invar",
+		GALVANIZED_STEEL = "galvanized-steel"
+	},
 
-Stock = {
-	PLATE     = "plate",
-	SHEET     = "sheet",
-	SQUARE    = "square",
-	ANGLE     = "angle",
-	GIRDER    = "girder",
-	WIRE      = "wire",
-	GEAR      = "gear",
-	FINE_GEAR = "fine-gear",
-	PIPE      = "pipe",
-	FINE_PIPE = "fine-pipe"
-}
+	Stock = {
+		PLATE     = "plate",
+		SHEET     = "sheet",
+		SQUARE    = "square",
+		ANGLE     = "angle",
+		GIRDER    = "girder",
+		WIRE      = "wire",
+		GEAR      = "gear",
+		FINE_GEAR = "fine-gear",
+		PIPE      = "pipe",
+		FINE_PIPE = "fine-pipe"
+	},
 
-Machined_Part = {
-	PANELING       = "paneling",
-	LARGE_PANELING = "large-paneling",
-	FRAMING        = "framing",
-	GIRDERING      = "girdering",
-	GEARING        = "gearing",
-	FINE_GEARING   = "fine-gearing",
-	PIPING         = "piping",
-	FINE_PIPING    = "fine-piping",
-	WIRING         = "wiring",
-	SHIELDING      = "shielding",
-	SHAFTING       = "shafting",
-	BOLTS          = "bolts",
-	RIVETS         = "rivets"
-}
+	Machined_Part = {
+		PANELING       = "paneling",
+		LARGE_PANELING = "large-paneling",
+		FRAMING        = "framing",
+		GIRDERING      = "girdering",
+		GEARING        = "gearing",
+		FINE_GEARING   = "fine-gearing",
+		PIPING         = "piping",
+		FINE_PIPING    = "fine-piping",
+		WIRING         = "wiring",
+		SHIELDING      = "shielding",
+		SHAFTING       = "shafting",
+		BOLTS          = "bolts",
+		RIVETS         = "rivets"
+	},
 
-Machined_Part_Property = {
-	BASIC                   = "basic",
-	LOAD_BEARING            = "load-bearing",
-	ELECTRICALLY_CONDUCTIVE = "electrically-conductive",
-	HIGH_TENSILE            = "high-tensile",
-	CORROSION_RESISTANT     = "corrosion-resistant",
-	LIGHTWEIGHT             = "lightweight",
-	DUCTILE                 = "ductile",
-	THERMALLY_STABLE        = "thermally-stable",
-	THERMALLY_CONDUCTIVE    = "thermally-conductive",
-	RADIATION_RESISTANT     = "radiation-resistant",
-	VERY_HIGH_TENSILE       = "very-high-tensile",
-	HEAVY_LOAD_BEARING      = "heavy-load-bearing",
-	HIGH_MELTING_POINT      = "high-melting-point"
-}
+	Machined_Part_Property = {
+		BASIC                   = "basic",
+		LOAD_BEARING            = "load-bearing",
+		ELECTRICALLY_CONDUCTIVE = "electrically-conductive",
+		HIGH_TENSILE            = "high-tensile",
+		CORROSION_RESISTANT     = "corrosion-resistant",
+		LIGHTWEIGHT             = "lightweight",
+		DUCTILE                 = "ductile",
+		THERMALLY_STABLE        = "thermally-stable",
+		THERMALLY_CONDUCTIVE    = "thermally-conductive",
+		RADIATION_RESISTANT     = "radiation-resistant",
+		VERY_HIGH_TENSILE       = "very-high-tensile",
+		HEAVY_LOAD_BEARING      = "heavy-load-bearing",
+		HIGH_MELTING_POINT      = "high-melting-point"
+	},
 
-Minisembler = {
-	WELDER         = "welder",
-	DRILL_PRESS    = "drill-press",
-	GRINDER        = "grinder",
-	METAL_BANDSAW  = "metal-bandsaw",
-	METAL_EXTRUDER = "metal-extruder",
-	MILL           = "mill",
-	METAL_LATHE    = "metal-lathe",
-	THREADER       = "threader",
-	SPOOLER        = "spooler",
-	ROLLER         = "roller",
-	BENDER         = "bender"
+	Minisembler = {
+		WELDER         = "welder",
+		DRILL_PRESS    = "drill-press",
+		GRINDER        = "grinder",
+		METAL_BANDSAW  = "metal-bandsaw",
+		METAL_EXTRUDER = "metal-extruder",
+		MILL           = "mill",
+		METAL_LATHE    = "metal-lathe",
+		THREADER       = "threader",
+		SPOOLER        = "spooler",
+		ROLLER         = "roller",
+		BENDER         = "bender"
+	}
 }

--- a/intermediates/mw-code.lua
+++ b/intermediates/mw-code.lua
@@ -16,6 +16,9 @@ local machined_part_stack_size = 200
 local stock_stack_size = 200
 local ore_stack_size = 200
 
+-- Enums variables
+require("enums")
+
 -- Challenge variables
 local advanced = settings.startup["gm-advanced-mode"].value
 local specialty_parts = false -- not implimented yet
@@ -455,7 +458,7 @@ for metal, stocks in pairs(metal_stocks_pairs) do -- Make the [Metal] [Stock] It
         localised_description = {"gm.metal-stock-item-description", {"gm." .. metal}, {"gm." .. stock}, property_list, produces_list_pieces[1], produces_list_pieces[2], produces_list_pieces[3], produces_list_pieces[4], produces_list_pieces[5], produces_list_pieces[6]}
       }
     })
-    if (stock ~= "plate") then
+    if (stock ~= Stock.PLATE) then
       local recipe = { -- recipe
         type = "recipe",
         name = metal .. "-" .. stock .. "-stock",
@@ -476,7 +479,7 @@ for metal, stocks in pairs(metal_stocks_pairs) do -- Make the [Metal] [Stock] It
         category = "gm-" .. stock_minisembler_pairs[stock],
         localised_name = {"gm.metal-stock-item-name", {"gm." .. metal}, {"gm." .. stock}}
       }
-      if ((metal == "copper" or metal == "iron") or (metal == "brass" and (stock == "pipe" or stock == "fine-pipe" or stock == "sheet"))) then
+      if ((metal == Resources.COPPER or metal == Resources.IRON) or (metal == Resources.BRASS and (stock == Stock.PIPE or stock == Stock.FINE-PIPE or stock == Stock.SHEET))) then
         recipe.category = recipe.category .. "-player-crafting"
         recipe.hide_from_player_crafting = false
       end
@@ -679,20 +682,20 @@ for property, parts in pairs(property_machined_part_pairs) do -- Make the [Prope
           localised_name = {"gm.machined-part-recipe", {"gm." .. property}, {"gm." .. part}, {"gm." .. metal}, {"gm." .. machined_parts_precurors[part][1]}}
         }
         if (advanced and ( -- carve-outs for player crafting for bootstrap purposes
-                          (property == "basic"                        and metal == "copper"                                                                                ) or
-                          (property == "basic"                        and metal == "iron"                                                                                  ) or
-                          (property == "electrically-conductive"      and metal == "copper" and machined_parts_precurors[part][1] == "wire"      and part == "wiring"      ) or
-                          (property == "thermally-conductive"         and metal == "copper" and machined_parts_precurors[part][1] == "wire"      and part == "wiring"      ) or
-                          (property == "corrosion-resistant"          and metal == "brass"  and machined_parts_precurors[part][1] == "fine-pipe" and part == "fine-piping" ) or
-                          (property == "corrosion-resistant"          and metal == "brass"  and machined_parts_precurors[part][1] == "pipe"      and part == "piping"      )
+                          (property == Machined_Part_Property.BASIC                        and metal == Resources.COPPER                                                                                                ) or
+                          (property == Machined_Part_Property.BASIC                        and metal == Resources.IRON                                                                                                  ) or
+                          (property == Machined_Part_Property.ELECTRICALLY_CONDUCTIVE      and metal == Resources.COPPER and machined_parts_precurors[part][1] == Stock.WIRE      and part == Machined_Part.WIRING      ) or
+                          (property == Machined_Part_Property.THERMALLY_CONDUCTIVE         and metal == Resources.COPPER and machined_parts_precurors[part][1] == Stock.WIRE      and part == Machined_Part.WIRING      ) or
+                          (property == Machined_Part_Property.CORROSION_RESISTANT          and metal == Resources.BRASS  and machined_parts_precurors[part][1] == Stock.FINE-PIPE and part == Machined_Part.FINE-PIPING ) or
+                          (property == Machined_Part_Property.CORROSION_RESISTANT          and metal == Resources.BRASS  and machined_parts_precurors[part][1] == Stock.PIPE      and part == Machined_Part.PIPING      )
                           )
             ) or
             (advanced == false and (
-                          (property == "basic"                        and metal == "copper"                                                                        ) or
-                          (property == "basic"                        and metal == "iron"                                                                          ) or
-                          (property == "electrically-conductive"      and metal == "copper" and machined_parts_precurors[part][1] == "square" and part == "wiring" ) or
-                          (property == "thermally-conductive"         and metal == "copper" and machined_parts_precurors[part][1] == "square" and part == "wiring" ) or
-                          (property == "corrosion-resistant"          and metal == "brass"  and machined_parts_precurors[part][1] == "plate"  and part == "piping" )
+                          (property == Machined_Part_Property.BASIC                        and metal == Resources.COPPER                                                                                        ) or
+                          (property == Machined_Part_Property.BASIC                        and metal == Resources.IRON                                                                                          ) or
+                          (property == Machined_Part_Property.ELECTRICALLY_CONDUCTIVE      and metal == Resources.COPPER and machined_parts_precurors[part][1] == Stock.SQUARE and part == Machined_Part.WIRING ) or
+                          (property == Machined_Part_Property.THERMALLY_CONDUCTIVE         and metal == Resources.COPPER and machined_parts_precurors[part][1] == Stock.SQUARE and part == Machined_Part.WIRING ) or
+                          (property == Machined_Part_Property.CORROSION_RESISTANT          and metal == Resources.BRASS  and machined_parts_precurors[part][1] == Stock.PLATE  and part == Machined_Part.PIPING )
                           )
             )
         then
@@ -748,7 +751,7 @@ data:extend({ -- Make the minisemblers item group and technology
 
 for minisembler, _ in pairs(minisemblers_recipe_parameters) do -- From the table minisemblers_recipe_parameters, default unset entries to the lathe by default
   if minisemblers_rendering_data[minisembler] == nil then
-    minisemblers_rendering_data[minisembler] = minisemblers_rendering_data["metal-lathe"]
+    minisemblers_rendering_data[minisembler] = minisemblers_rendering_data[Minisembler.METAL_LATHE]
   end
 end
 

--- a/intermediates/mw-code.lua
+++ b/intermediates/mw-code.lua
@@ -17,7 +17,12 @@ local stock_stack_size = 200
 local ore_stack_size = 200
 
 -- Enums variables
-require("enums")
+local enums = require("enums")
+local Resources = enums.Resources
+local Stock = enums.Stock
+local Machined_Part = enums.Machined_Part
+local Machined_Part_Property = enums.Machined_Part_Property
+local Minisembler = enums.Minisembler
 
 -- Challenge variables
 local advanced = settings.startup["gm-advanced-mode"].value
@@ -479,7 +484,7 @@ for metal, stocks in pairs(metal_stocks_pairs) do -- Make the [Metal] [Stock] It
         category = "gm-" .. stock_minisembler_pairs[stock],
         localised_name = {"gm.metal-stock-item-name", {"gm." .. metal}, {"gm." .. stock}}
       }
-      if ((metal == Resources.COPPER or metal == Resources.IRON) or (metal == Resources.BRASS and (stock == Stock.PIPE or stock == Stock.FINE-PIPE or stock == Stock.SHEET))) then
+      if ((metal == Resources.COPPER or metal == Resources.IRON) or (metal == Resources.BRASS and (stock == Stock.PIPE or stock == Stock.FINE_PIPE or stock == Stock.SHEET))) then
         recipe.category = recipe.category .. "-player-crafting"
         recipe.hide_from_player_crafting = false
       end
@@ -686,7 +691,7 @@ for property, parts in pairs(property_machined_part_pairs) do -- Make the [Prope
                           (property == Machined_Part_Property.BASIC                        and metal == Resources.IRON                                                                                                  ) or
                           (property == Machined_Part_Property.ELECTRICALLY_CONDUCTIVE      and metal == Resources.COPPER and machined_parts_precurors[part][1] == Stock.WIRE      and part == Machined_Part.WIRING      ) or
                           (property == Machined_Part_Property.THERMALLY_CONDUCTIVE         and metal == Resources.COPPER and machined_parts_precurors[part][1] == Stock.WIRE      and part == Machined_Part.WIRING      ) or
-                          (property == Machined_Part_Property.CORROSION_RESISTANT          and metal == Resources.BRASS  and machined_parts_precurors[part][1] == Stock.FINE-PIPE and part == Machined_Part.FINE-PIPING ) or
+                          (property == Machined_Part_Property.CORROSION_RESISTANT          and metal == Resources.BRASS  and machined_parts_precurors[part][1] == Stock.FINE_PIPE and part == Machined_Part.FINE_PIPING ) or
                           (property == Machined_Part_Property.CORROSION_RESISTANT          and metal == Resources.BRASS  and machined_parts_precurors[part][1] == Stock.PIPE      and part == Machined_Part.PIPING      )
                           )
             ) or

--- a/intermediates/mw-data.lua
+++ b/intermediates/mw-data.lua
@@ -1,3 +1,5 @@
+require("enums")
+
 -- ********
 -- Settings
 -- ********
@@ -33,9 +35,9 @@ end
 
 local minisembler_recipe_ordering
 if advanced then
-  minisembler_recipe_ordering = {"paneling", "framing", "fine-gearing", "wiring", "shafting", "bolts"}
+  minisembler_recipe_ordering = {Machined_Part.PANELING, Machined_Part.FRAMING, Machined_Part.FINE_GEARING, Machined_Part.WIRING, Machined_Part.SHAFTING, Machined_Part.BOLTS}
 else
-  minisembler_recipe_ordering = {"paneling", "framing", "gearing", "wiring", "shafting", "bolts"}
+  minisembler_recipe_ordering = {Machined_Part.PANELING, Machined_Part.FRAMING, Machined_Part.GEARING, Machined_Part.WIRING, Machined_Part.SHAFTING, Machined_Part.BOLTS}
 end
 
 local function map_minisembler_recipes(t)
@@ -43,7 +45,7 @@ local function map_minisembler_recipes(t)
   local counter = 1
   for _, part in pairs(minisembler_recipe_ordering) do
     if t[counter] > 0 then
-      if part == "wiring" then
+      if part == Machined_Part.WIRING then
         table.insert(returnTable, #returnTable, {"electrically-conductive-" .. part .. "-machined-part", t[counter]})
       else 
         table.insert(returnTable, #returnTable, {"basic-" .. part .. "-machined-part", t[counter]})
@@ -67,58 +69,58 @@ end
 -- ===
 
 local original_ores = {
-  ["copper"] = true,
-  ["iron"] = true,
+  [Resources.COPPER] = true,
+  [Resources.IRON] = true,
   -- ["uranium-ore"] = true,
-  -- ["coal"] = true,
-  -- ["stone"] = true
+  -- [Resources.COAL] = true,
+  -- [Resources.STONE] = true
 }
 
 -- Redo the art for the current ores
 local base_resources_to_replace_with_ore_in_the_stupid_name = {
-  ["copper"] = true,
-  ["iron"] = true,
+  [Resources.COPPER] = true,
+  [Resources.IRON] = true,
   -- ["uranium"] = true,
 }
 
 local base_resources_to_replace_without_ore_in_the_stupid_name = {
-  ["coal"] = true,
-  ["stone"] = true,
+  [Resources.COAL] = true,
+  [Resources.STONE] = true,
 }
 
 local ores_to_include_starting_area = {
-  ["zinc"]     = true,
-  ["lead"]     = false,
-  ["titanium"] = false,
-  ["nickel"]   = false,
-  ["copper"]   = true,
-  ["iron"]     = true
+  [Resources.ZINC]     = true,
+  [Resources.LEAD]     = false,
+  [Resources.TITANIUM] = false,
+  [Resources.NICKEL]   = false,
+  [Resources.COPPER]   = true,
+  [Resources.IRON]     = true
 }
 
 local metals_to_add = { -- ***ORE***
-  ["lead"]     = true,
-  ["titanium"] = true,
-  ["zinc"]     = true,
-  ["nickel"]   = true,
+  [Resources.LEAD]     = true,
+  [Resources.TITANIUM] = true,
+  [Resources.ZINC]     = true,
+  [Resources.NICKEL]   = true,
 }
 
 -- Metals
 -- ======
 
 local metals_to_use = { -- ***ORE***
-  ["lead"]     = true,
-  ["titanium"] = true,
-  ["zinc"]     = true,
-  ["nickel"]   = true,
-  ["copper"]   = true,
-  ["iron"]     = true
+  [Resources.LEAD]     = true,
+  [Resources.TITANIUM] = true,
+  [Resources.ZINC]     = true,
+  [Resources.NICKEL]   = true,
+  [Resources.COPPER]   = true,
+  [Resources.IRON]     = true
 }
 
 local alloy_recipe = {
-  ["steel"]            = {{"iron-plate-stock", 5},   {"coal", 1}},
-  ["brass"]            = {{"copper-plate-stock", 3}, {"zinc-plate-stock", 1}},
-  ["invar"]            = {{"iron-plate-stock", 3},   {"nickel-plate-stock", 2}},
-  ["galvanized-steel"] = {{"steel-plate-stock", 5},  {"zinc-plate-stock", 1}}
+  [Resources.STEEL]            = {{"iron-plate-stock", 5},   {Resources.COAL, 1}},
+  [Resources.BRASS]            = {{"copper-plate-stock", 3}, {"zinc-plate-stock", 1}},
+  [Resources.INVAR]            = {{"iron-plate-stock", 3},   {"nickel-plate-stock", 2}},
+  [Resources.GALVANIZED_STEEL] = {{"steel-plate-stock", 5},  {"zinc-plate-stock", 1}}
 }
 
 -- Stocks
@@ -133,59 +135,59 @@ local alloy_recipe = {
 local minisemblers_rgba_pairs
 if advanced then -- minisemblers_rgba_pairs: [minisembler | {rgba values}]  FIXME: This needs a new name and to loose the rgba data because that doesn't get used.
   minisemblers_rgba_pairs = {
-    ["welder"]          = {r = 1.0, g = 1.0, b = 1.0, a = 1.0},
-    ["drill-press"]     = {r = 0.6, g = 1.0, b = 1.0, a = 1.0},
-    ["grinder"]         = {r = 1.0, g = 0.6, b = 1.0, a = 1.0},
-    ["metal-bandsaw"]   = {r = 1.0, g = 1.0, b = 0.6, a = 1.0},
-    ["metal-extruder"]  = {r = 0.7, g = 0.6, b = 1.0, a = 1.0},
-    ["mill"]            = {r = 1.0, g = 0.6, b = 0.6, a = 1.0},
-    ["metal-lathe"]     = {r = 0.6, g = 1.0, b = 0.6, a = 1.0},
-    ["threader"]        = {r = 0.2, g = 1.0, b = 1.0, a = 1.0},
-    ["spooler"]         = {r = 1.0, g = 0.2, b = 1.0, a = 1.0},
-    ["roller"]          = {r = 1.0, g = 1.0, b = 0.2, a = 1.0},
-    ["bender"]          = {r = 0.2, g = 0.2, b = 1.0, a = 1.0}
+    [Minisembler.WELDER]          = {r = 1.0, g = 1.0, b = 1.0, a = 1.0},
+    [Minisembler.DRILL_PRESS]     = {r = 0.6, g = 1.0, b = 1.0, a = 1.0},
+    [Minisembler.GRINDER]         = {r = 1.0, g = 0.6, b = 1.0, a = 1.0},
+    [Minisembler.METAL_BANDSAW]   = {r = 1.0, g = 1.0, b = 0.6, a = 1.0},
+    [Minisembler.METAL_EXTRUDER]  = {r = 0.7, g = 0.6, b = 1.0, a = 1.0},
+    [Minisembler.MILL]            = {r = 1.0, g = 0.6, b = 0.6, a = 1.0},
+    [Minisembler.METAL_LATHE]     = {r = 0.6, g = 1.0, b = 0.6, a = 1.0},
+    [Minisembler.THREADER]        = {r = 0.2, g = 1.0, b = 1.0, a = 1.0},
+    [Minisembler.SPOOLER]         = {r = 1.0, g = 0.2, b = 1.0, a = 1.0},
+    [Minisembler.ROLLER]          = {r = 1.0, g = 1.0, b = 0.2, a = 1.0},
+    [Minisembler.BENDER]          = {r = 0.2, g = 0.2, b = 1.0, a = 1.0}
   }
 else
     minisemblers_rgba_pairs = {
-    ["metal-bandsaw"]   = {r = 1.0, g = 1.0, b = 0.6, a = 1.0},
-    ["metal-extruder"]  = {r = 0.6, g = 0.6, b = 1.0, a = 1.0},
-    ["mill"]            = {r = 1.0, g = 0.6, b = 0.6, a = 1.0},
-    ["metal-lathe"]     = {r = 0.6, g = 1.0, b = 0.6, a = 1.0},
-    ["roller"]          = {r = 1.0, g = 1.0, b = 0.2, a = 1.0},
-    ["bender"]          = {r = 0.2, g = 0.2, b = 1.0, a = 1.0}
+    [Minisembler.METAL_BANDSAW]   = {r = 1.0, g = 1.0, b = 0.6, a = 1.0},
+    [Minisembler.METAL_EXTRUDER]  = {r = 0.6, g = 0.6, b = 1.0, a = 1.0},
+    [Minisembler.MILL]            = {r = 1.0, g = 0.6, b = 0.6, a = 1.0},
+    [Minisembler.METAL_LATHE]     = {r = 0.6, g = 1.0, b = 0.6, a = 1.0},
+    [Minisembler.ROLLER]          = {r = 1.0, g = 1.0, b = 0.2, a = 1.0},
+    [Minisembler.BENDER]          = {r = 0.2, g = 0.2, b = 1.0, a = 1.0}
   }
 end
 
 local minisemblers_recipe_parameters
 if advanced then -- Store data to differentiate the different minisemblers
   minisemblers_recipe_parameters = {
-    ["welder"]          = map_minisembler_recipes{1, 2, 1, 2, 0, 1},
-    ["drill-press"]     = map_minisembler_recipes{1, 1, 2, 1, 0, 1},
-    ["grinder"]         = map_minisembler_recipes{1, 2, 1, 1, 1, 1},
-    ["metal-bandsaw"]   = map_minisembler_recipes{1, 1, 1, 1, 0, 2},
-    ["metal-extruder"]  = map_minisembler_recipes{1, 1, 1, 3, 0, 1},
-    ["mill"]            = map_minisembler_recipes{1, 2, 2, 1, 1, 1},
-    ["metal-lathe"]     = map_minisembler_recipes{1, 1, 1, 1, 1, 1},
-    ["threader"]        = map_minisembler_recipes{1, 1, 2, 1, 0, 1},
-    ["spooler"]         = map_minisembler_recipes{1, 1, 2, 2, 1, 1},
-    ["roller"]          = map_minisembler_recipes{1, 3, 1, 1, 2, 1},
-    ["bender"]          = map_minisembler_recipes{1, 3, 1, 1, 0, 1}
+    [Minisembler.WELDER]          = map_minisembler_recipes{1, 2, 1, 2, 0, 1},
+    [Minisembler.DRILL_PRESS]     = map_minisembler_recipes{1, 1, 2, 1, 0, 1},
+    [Minisembler.GRINDER]         = map_minisembler_recipes{1, 2, 1, 1, 1, 1},
+    [Minisembler.METAL_BANDSAW]   = map_minisembler_recipes{1, 1, 1, 1, 0, 2},
+    [Minisembler.METAL_EXTRUDER]  = map_minisembler_recipes{1, 1, 1, 3, 0, 1},
+    [Minisembler.MILL]            = map_minisembler_recipes{1, 2, 2, 1, 1, 1},
+    [Minisembler.METAL_LATHE]     = map_minisembler_recipes{1, 1, 1, 1, 1, 1},
+    [Minisembler.THREADER]        = map_minisembler_recipes{1, 1, 2, 1, 0, 1},
+    [Minisembler.SPOOLER]         = map_minisembler_recipes{1, 1, 2, 2, 1, 1},
+    [Minisembler.ROLLER]          = map_minisembler_recipes{1, 3, 1, 1, 2, 1},
+    [Minisembler.BENDER]          = map_minisembler_recipes{1, 3, 1, 1, 0, 1}
   }
 else
   minisemblers_recipe_parameters = {
-    ["welder"]          = map_minisembler_recipes{1, 2, 1, 2, 0, 1},
-    ["metal-bandsaw"]   = map_minisembler_recipes{1, 1, 1, 1, 0, 2},
-    ["metal-extruder"]  = map_minisembler_recipes{1, 1, 1, 3, 0, 1},
-    ["mill"]            = map_minisembler_recipes{1, 2, 2, 1, 1, 1},
-    ["metal-lathe"]     = map_minisembler_recipes{1, 1, 1, 1, 1, 1},
-    ["roller"]          = map_minisembler_recipes{1, 3, 1, 1, 2, 1},
-    ["bender"]          = map_minisembler_recipes{1, 3, 1, 1, 0, 1}
+    [Minisembler.WELDER]          = map_minisembler_recipes{1, 2, 1, 2, 0, 1},
+    [Minisembler.METAL_BANDSAW]   = map_minisembler_recipes{1, 1, 1, 1, 0, 2},
+    [Minisembler.METAL_EXTRUDER]  = map_minisembler_recipes{1, 1, 1, 3, 0, 1},
+    [Minisembler.MILL]            = map_minisembler_recipes{1, 2, 2, 1, 1, 1},
+    [Minisembler.METAL_LATHE]     = map_minisembler_recipes{1, 1, 1, 1, 1, 1},
+    [Minisembler.ROLLER]          = map_minisembler_recipes{1, 3, 1, 1, 2, 1},
+    [Minisembler.BENDER]          = map_minisembler_recipes{1, 3, 1, 1, 0, 1}
   }
 end
 
 local minisemblers_rendering_data = { -- Set up the minisembler rendering data
   -- metal-lathe
-  ["metal-lathe"] = {
+  [Minisembler.METAL_LATHE] = {
     ["frame-count"] = 24,
     ["line-length"] = 5,
     ["hr"] = {
@@ -308,146 +310,146 @@ local minisemblers_rendering_data = { -- Set up the minisembler rendering data
 
 local metal_technology_pairs = {
   -- pure metals
-  ["iron"]              = {"vanilla", "starter"},
-  ["copper"]            = {"vanilla", "starter"},
-  ["lead"]              = {"vanilla", "gm-lead-stock-processing", "gm-lead-machined-part-processing"},
-  ["titanium"]          = {"vanilla", "gm-titanium-stock-processing", "gm-titanium-machined-part-processing"},
-  ["zinc"]              = {"vanilla", "starter"},
-  ["nickel"]            = {"vanilla", "gm-nickel-and-invar-stock-processing", "gm-nickel-and-invar-machined-part-processing"},
+  [Resources.IRON]              = {"vanilla", "starter"},
+  [Resources.COPPER]            = {"vanilla", "starter"},
+  [Resources.LEAD]              = {"vanilla", "gm-lead-stock-processing", "gm-lead-machined-part-processing"},
+  [Resources.TITANIUM]          = {"vanilla", "gm-titanium-stock-processing", "gm-titanium-machined-part-processing"},
+  [Resources.ZINC]              = {"vanilla", "starter"},
+  [Resources.NICKEL]            = {"vanilla", "gm-nickel-and-invar-stock-processing", "gm-nickel-and-invar-machined-part-processing"},
 
   -- alloys 
-  ["steel"]             = {"vanilla", "steel-processing", "steel-machined-part-processing"},
-  ["brass"]             = {"vanilla", "starter"},
-  ["invar"]             = {"vanilla", "gm-nickel-and-invar-stock-processing", "gm-nickel-and-invar-machined-part-processing"},
+  [Resources.STEEL]             = {"vanilla", "steel-processing", "steel-machined-part-processing"},
+  [Resources.BRASS]             = {"vanilla", "starter"},
+  [Resources.INVAR]             = {"vanilla", "gm-nickel-and-invar-stock-processing", "gm-nickel-and-invar-machined-part-processing"},
 
   -- treatments 
-  ["galvanized-steel"]  = {"vanilla", "gm-galvanized-steel-stock-processing", "gm-galvanized-steel-machined-part-processing"},
+  [Resources.GALVANIZED_STEEL]  = {"vanilla", "gm-galvanized-steel-stock-processing", "gm-galvanized-steel-machined-part-processing"},
 }
 
 local metal_properties_pairs = { -- [metal | list of properties] 
   -- elemental metal
-  ["iron"]             = map{"basic", "load-bearing"},
-  ["copper"]           = map{"basic", "thermally-conductive", "electrically-conductive"},
-  ["lead"]             = map{"basic", "radiation-resistant"},
-  ["titanium"]         = map{"basic", "load-bearing", "heavy-load-bearing", "high-tensile", "very-high-tensile", "lightweight", "high-melting-point"},
-  ["zinc"]             = map{"basic"},
-  ["nickel"]           = map{"basic", "load-bearing", "ductile"},
+  [Resources.IRON]             = map{Machined_Part_Property.BASIC, Machined_Part_Property.LOAD_BEARING},
+  [Resources.COPPER]           = map{Machined_Part_Property.BASIC, Machined_Part_Property.THERMALLY_CONDUCTIVE, Machined_Part_Property.ELECTRICALLY_CONDUCTIVE},
+  [Resources.LEAD]             = map{Machined_Part_Property.BASIC, Machined_Part_Property.RADIATION_RESISTANT},
+  [Resources.TITANIUM]         = map{Machined_Part_Property.BASIC, Machined_Part_Property.LOAD_BEARING, Machined_Part_Property.HEAVY_LOAD_BEARING, Machined_Part_Property.HIGH_TENSILE, Machined_Part_Property.VERY_HIGH_TENSILE, Machined_Part_Property.LIGHTWEIGHT, Machined_Part_Property.HIGH_MELTING_POINT},
+  [Resources.ZINC]             = map{Machined_Part_Property.BASIC},
+  [Resources.NICKEL]           = map{Machined_Part_Property.BASIC, Machined_Part_Property.LOAD_BEARING, Machined_Part_Property.DUCTILE},
 
   -- alloyed metal
-  ["steel"]            = map{"basic", "high-tensile", "load-bearing", "heavy-load-bearing"},
-  ["brass"]            = map{"basic", "ductile", "corrosion-resistant"},
-  ["invar"]            = map{"basic", "load-bearing", "thermally-stable", "high-tensile"},
+  [Resources.STEEL]            = map{Machined_Part_Property.BASIC, Machined_Part_Property.HIGH_TENSILE, Machined_Part_Property.LOAD_BEARING, Machined_Part_Property.HEAVY_LOAD_BEARING},
+  [Resources.BRASS]            = map{Machined_Part_Property.BASIC, Machined_Part_Property.DUCTILE, Machined_Part_Property.CORROSION_RESISTANT},
+  [Resources.INVAR]            = map{Machined_Part_Property.BASIC, Machined_Part_Property.LOAD_BEARING, Machined_Part_Property.THERMALLY_STABLE, Machined_Part_Property.HIGH_TENSILE},
 
   -- treated metals
-  ["galvanized-steel"] = map{"basic", "corrosion-resistant", "high-tensile", "load-bearing", "heavy-load-bearing"},
+  [Resources.GALVANIZED_STEEL] = map{Machined_Part_Property.BASIC, Machined_Part_Property.CORROSION_RESISTANT, Machined_Part_Property.HIGH_TENSILE, Machined_Part_Property.LOAD_BEARING, Machined_Part_Property.HEAVY_LOAD_BEARING},
 }
 
 local metal_tinting_pairs = { -- [metal | {primary RGBA, secondary RGBA}]
   -- elemental metal
-  ["iron"]             = {gamma_correct_rgb{r = 0.32,  g = 0.32,  b = 0.32,  a = 1.0}, gamma_correct_rgb{r = 0.206, g = 0.077, b = 0.057, a = 1.0}},
-  ["copper"]           = {gamma_correct_rgb{r = 1.0,   g = 0.183, b = 0.013, a = 1.0}, gamma_correct_rgb{r = 0.144, g = 0.177, b = 0.133, a = 1.0}},
-  ["lead"]             = {gamma_correct_rgb{r = 0.241, g = 0.241, b = 0.241, a = 1.0}, gamma_correct_rgb{r = 0.847, g = 0.748, b = 0.144, a = 1.0}},
-  ["titanium"]         = {gamma_correct_rgb{r = 0.32,  g = 0.32,  b = 0.32,  a = 1.0}, gamma_correct_rgb{r = 1.0,   g = 1.0,   b = 1.0,   a = 1.0}},
-  ["zinc"]             = {gamma_correct_rgb{r = 0.241, g = 0.241, b = 0.241, a = 1.0}, gamma_correct_rgb{r = 0.205, g = 0.076, b = 0.0,   a = 1.0}},
-  ["nickel"]           = {gamma_correct_rgb{r = 0.984, g = 0.984, b = 0.984, a = 1.0}, gamma_correct_rgb{r = 0.388, g = 0.463, b = 0.314, a = 1.0}},
+  [Resources.IRON]             = {gamma_correct_rgb{r = 0.32,  g = 0.32,  b = 0.32,  a = 1.0}, gamma_correct_rgb{r = 0.206, g = 0.077, b = 0.057, a = 1.0}},
+  [Resources.COPPER]           = {gamma_correct_rgb{r = 1.0,   g = 0.183, b = 0.013, a = 1.0}, gamma_correct_rgb{r = 0.144, g = 0.177, b = 0.133, a = 1.0}},
+  [Resources.LEAD]             = {gamma_correct_rgb{r = 0.241, g = 0.241, b = 0.241, a = 1.0}, gamma_correct_rgb{r = 0.847, g = 0.748, b = 0.144, a = 1.0}},
+  [Resources.TITANIUM]         = {gamma_correct_rgb{r = 0.32,  g = 0.32,  b = 0.32,  a = 1.0}, gamma_correct_rgb{r = 1.0,   g = 1.0,   b = 1.0,   a = 1.0}},
+  [Resources.ZINC]             = {gamma_correct_rgb{r = 0.241, g = 0.241, b = 0.241, a = 1.0}, gamma_correct_rgb{r = 0.205, g = 0.076, b = 0.0,   a = 1.0}},
+  [Resources.NICKEL]           = {gamma_correct_rgb{r = 0.984, g = 0.984, b = 0.984, a = 1.0}, gamma_correct_rgb{r = 0.388, g = 0.463, b = 0.314, a = 1.0}},
 
   -- alloyed metal
-  ["steel"]            = {gamma_correct_rgb{r = 0.111, g = 0.111, b = 0.111, a = 1.0}, gamma_correct_rgb{r = 0.186, g = 0.048, b = 0.026, a = 1.0}},
-  ["brass"]            = {gamma_correct_rgb{r = 1.0,   g = 0.4,   b = 0.071, a = 1.0}, gamma_correct_rgb{r = 0.069, g = 0.131, b = 0.018, a = 1.0}},
-  ["invar"]            = {gamma_correct_rgb{r = 0.984, g = 0.965, b = 0.807, a = 1.0}, gamma_correct_rgb{r = 0.427, g = 0.333, b = 0.220, a = 1.0}},
+  [Resources.STEEL]            = {gamma_correct_rgb{r = 0.111, g = 0.111, b = 0.111, a = 1.0}, gamma_correct_rgb{r = 0.186, g = 0.048, b = 0.026, a = 1.0}},
+  [Resources.BRASS]            = {gamma_correct_rgb{r = 1.0,   g = 0.4,   b = 0.071, a = 1.0}, gamma_correct_rgb{r = 0.069, g = 0.131, b = 0.018, a = 1.0}},
+  [Resources.INVAR]            = {gamma_correct_rgb{r = 0.984, g = 0.965, b = 0.807, a = 1.0}, gamma_correct_rgb{r = 0.427, g = 0.333, b = 0.220, a = 1.0}},
 
   -- treated metal
-  ["galvanized-steel"] = {gamma_correct_rgb{r = 0.095, g = 0.104, b = 0.148, a = 1.0}, gamma_correct_rgb{r = 0.095, g = 0.104, b = 0.148, a = 1.0}}  
+  [Resources.GALVANIZED_STEEL] = {gamma_correct_rgb{r = 0.095, g = 0.104, b = 0.148, a = 1.0}, gamma_correct_rgb{r = 0.095, g = 0.104, b = 0.148, a = 1.0}}  
 }
 
 local metal_stocks_pairs
 if advanced then -- metal_stocks_pairs : [metal | list of stocks that it has]
   metal_stocks_pairs = {
     -- elemental metal
-    ["iron"]              = map{"plate", "sheet", "square", "angle", "girder", "wire", "gear", "fine-gear", "pipe", "fine-pipe"},
-    ["copper"]            = map{"plate", "sheet", "square",                    "wire", "gear", "fine-gear", "pipe", "fine-pipe"},
-    ["lead"]              = map{"plate", "sheet",                                                           "pipe", "fine-pipe"},
-    ["titanium"]          = map{"plate", "sheet", "square", "angle", "girder", "wire", "gear", "fine-gear", "pipe", "fine-pipe"},
-    ["zinc"]              = map{"plate"                                                                                        },
-    ["nickel"]            = map{"plate", "sheet", "square", "angle", "girder",         "gear", "fine-gear", "pipe", "fine-pipe"},
+    [Resources.IRON]              = map{Stock.PLATE, Stock.SHEET, Stock.SQUARE, Stock.ANGLE, Stock.GIRDER, Stock.WIRE, Stock.GEAR, Stock.FINE_GEAR, Stock.PIPE, Stock.FINE_PIPE},
+    [Resources.COPPER]            = map{Stock.PLATE, Stock.SHEET, Stock.SQUARE,                            Stock.WIRE, Stock.GEAR, Stock.FINE_GEAR, Stock.PIPE, Stock.FINE_PIPE},
+    [Resources.LEAD]              = map{Stock.PLATE, Stock.SHEET,                                                                                   Stock.PIPE, Stock.FINE_PIPE},
+    [Resources.TITANIUM]          = map{Stock.PLATE, Stock.SHEET, Stock.SQUARE, Stock.ANGLE, Stock.GIRDER, Stock.WIRE, Stock.GEAR, Stock.FINE_GEAR, Stock.PIPE, Stock.FINE_PIPE},
+    [Resources.ZINC]              = map{Stock.PLATE                                                                                                                            },
+    [Resources.NICKEL]            = map{Stock.PLATE, Stock.SHEET, Stock.SQUARE, Stock.ANGLE, Stock.GIRDER,             Stock.GEAR, Stock.FINE_GEAR, Stock.PIPE, Stock.FINE_PIPE},
 
     -- alloyed metal
-    ["steel"]             = map{"plate", "sheet", "square", "angle", "girder", "wire", "gear", "fine-gear", "pipe", "fine-pipe"},
-    ["brass"]             = map{"plate", "sheet", "square", "angle", "girder", "wire", "gear", "fine-gear", "pipe", "fine-pipe"},
-    ["invar"]             = map{"plate", "sheet", "square", "angle", "girder", "wire", "gear", "fine-gear", "pipe", "fine-pipe"},
+    [Resources.STEEL]             = map{Stock.PLATE, Stock.SHEET, Stock.SQUARE, Stock.ANGLE, Stock.GIRDER, Stock.WIRE, Stock.GEAR, Stock.FINE_GEAR, Stock.PIPE, Stock.FINE_PIPE},
+    [Resources.BRASS]             = map{Stock.PLATE, Stock.SHEET, Stock.SQUARE, Stock.ANGLE, Stock.GIRDER, Stock.WIRE, Stock.GEAR, Stock.FINE_GEAR, Stock.PIPE, Stock.FINE_PIPE},
+    [Resources.INVAR]             = map{Stock.PLATE, Stock.SHEET, Stock.SQUARE, Stock.ANGLE, Stock.GIRDER, Stock.WIRE, Stock.GEAR, Stock.FINE_GEAR, Stock.PIPE, Stock.FINE_PIPE},
 
     -- treated metal
-    ["galvanized-steel"]  = map{"plate", "sheet", "square", "angle", "girder", "wire", "gear", "fine-gear", "pipe", "fine-pipe"}
+    [Resources.GALVANIZED_STEEL]  = map{Stock.PLATE, Stock.SHEET, Stock.SQUARE, Stock.ANGLE, Stock.GIRDER, Stock.WIRE, Stock.GEAR, Stock.FINE_GEAR, Stock.PIPE, Stock.FINE_PIPE}
   }
 else
   metal_stocks_pairs = {
     -- pure metals
-    ["iron"]              = map{"plate", "square", "wire"},
-    ["copper"]            = map{"plate", "square", "wire"},
-    ["lead"]              = map{"plate",                 },
-    ["titanium"]          = map{"plate", "square", "wire"},
-    ["zinc"]              = map{"plate"                  },
-    ["nickel"]            = map{"plate", "square", "wire"},
+    [Resources.IRON]              = map{Stock.PLATE, Stock.SQUARE, Stock.WIRE},
+    [Resources.COPPER]            = map{Stock.PLATE, Stock.SQUARE, Stock.WIRE},
+    [Resources.LEAD]              = map{Stock.PLATE,                         },
+    [Resources.TITANIUM]          = map{Stock.PLATE, Stock.SQUARE, Stock.WIRE},
+    [Resources.ZINC]              = map{Stock.PLATE                          },
+    [Resources.NICKEL]            = map{Stock.PLATE, Stock.SQUARE, Stock.WIRE},
 
     -- alloys
-    ["steel"]             = map{"plate", "square", "wire"},
-    ["brass"]             = map{"plate", "square", "wire"},
-    ["invar"]             = map{"plate", "square", "wire"},
+    [Resources.STEEL]             = map{Stock.PLATE, Stock.SQUARE, Stock.WIRE},
+    [Resources.BRASS]             = map{Stock.PLATE, Stock.SQUARE, Stock.WIRE},
+    [Resources.INVAR]             = map{Stock.PLATE, Stock.SQUARE, Stock.WIRE},
 
     -- treatments
-    ["galvanized-steel"]  = map{"plate", "square", "wire"}
+    [Resources.GALVANIZED_STEEL]  = map{Stock.PLATE, Stock.SQUARE, Stock.WIRE}
   }
 end
 
 local stock_minisembler_pairs
 if advanced then -- stock_minisembler_pairs : [stock | minisembler]
   stock_minisembler_pairs = {
-    ["plate"]     = "smelting",
-    ["sheet"]     = "roller",
-    ["square"]    = "metal-bandsaw",
-    ["angle"]     = "bender",
-    ["girder"]    = "bender",
-    ["wire"]      = "metal-extruder",
-    ["gear"]      = "mill",
-    ["fine-gear"] = "mill",
-    ["pipe"]      = "roller",
-    ["fine-pipe"] = "roller"
+    [Stock.PLATE]     = "smelting",
+    [Stock.SHEET]     = Minisembler.ROLLER,
+    [Stock.SQUARE]    = Minisembler.METAL_BANDSAW,
+    [Stock.ANGLE]     = Minisembler.BENDER,
+    [Stock.GIRDER]    = Minisembler.BENDER,
+    [Stock.WIRE]      = Minisembler.METAL_EXTRUDER,
+    [Stock.GEAR]      = Minisembler.MILL,
+    [Stock.FINE_GEAR] = Minisembler.MILL,
+    [Stock.PIPE]      = Minisembler.ROLLER,
+    [Stock.FINE_PIPE] = Minisembler.ROLLER
   }
 else
   stock_minisembler_pairs = {
-    ["plate"]     = "smelting",
-    ["square"]    = "metal-bandsaw",
-    ["wire"]      = "metal-extruder"
+    [Stock.PLATE]     = "smelting",
+    [Stock.SQUARE]    = Minisembler.METAL_BANDSAW,
+    [Stock.WIRE]      = Minisembler.METAL_EXTRUDER
   }
 end
 
 local machined_part_minisembler_pairs
 if advanced then -- machined_part_minisembler_pairs : [machined part | minisembler]
   machined_part_minisembler_pairs = {
-    ["paneling"]        = "welder",
-    ["large-paneling"]  = "welder",
-    ["framing"]         = "drill-press",
-    ["girdering"]       = "grinder",
-    ["gearing"]         = "grinder",
-    ["fine-gearing"]    = "grinder",
-    ["piping"]          = "welder",
-    ["fine-piping"]     = "welder",
-    ["wiring"]          = "spooler",
-    ["shielding"]       = "mill",
-    ["shafting"]        = "metal-lathe",
-    ["bolts"]           = "threader",
-    ["rivets"]          = "metal-extruder"
+    [Machined_Part.PANELING]        = Minisembler.WELDER,
+    [Machined_Part.LARGE_PANELING]  = Minisembler.WELDER,
+    [Machined_Part.FRAMING]         = Minisembler.DRILL_PRESS,
+    [Machined_Part.GIRDERING]       = Minisembler.GRINDER,
+    [Machined_Part.GEARING]         = Minisembler.GRINDER,
+    [Machined_Part.FINE_GEARING]    = Minisembler.GRINDER,
+    [Machined_Part.PIPING]          = Minisembler.WELDER,
+    [Machined_Part.FINE_PIPING]     = Minisembler.WELDER,
+    [Machined_Part.WIRING]          = Minisembler.SPOOLER,
+    [Machined_Part.SHIELDING]       = Minisembler.MILL,
+    [Machined_Part.SHAFTING]        = Minisembler.METAL_LATHE,
+    [Machined_Part.BOLTS]           = Minisembler.THREADER,
+    [Machined_Part.RIVETS]          = Minisembler.METAL_EXTRUDER
   }
 else
   machined_part_minisembler_pairs = {
-    ["paneling"]  = "mill",
-    ["framing"]   = "bender",
-    ["gearing"]   = "mill",
-    ["piping"]    = "roller",
-    ["wiring"]    = "metal-extruder",
-    ["shielding"] = "mill",
-    ["shafting"]  = "metal-lathe",
-    ["bolts"]     = "metal-lathe"
+    [Machined_Part.PANELING]  = Minisembler.MILL,
+    [Machined_Part.FRAMING]   = Minisembler.BENDER,
+    [Machined_Part.GEARING]   = Minisembler.MILL,
+    [Machined_Part.PIPING]    = Minisembler.ROLLER,
+    [Machined_Part.WIRING]    = Minisembler.METAL_EXTRUDER,
+    [Machined_Part.SHIELDING] = Minisembler.MILL,
+    [Machined_Part.SHAFTING]  = Minisembler.METAL_LATHE,
+    [Machined_Part.BOLTS]     = Minisembler.METAL_LATHE
   }
 end
 
@@ -455,84 +457,83 @@ local property_machined_part_pairs
 if advanced then -- property_machined_part_pairs : [property | list of machined parts that are able to have that property]
   property_machined_part_pairs = {
     -- single-properties
-    ["basic"]                   = map{"paneling", "large-paneling", "framing", "girdering", "gearing", "fine-gearing", "piping", "fine-piping", "wiring", "shielding", "shafting", "bolts", "rivets"},
-    ["load-bearing"]            = map{                              "framing", "girdering",                                                                            "shafting"                   },
-    ["electrically-conductive"] = map{                                                                                                          "wiring"                                          },
-    ["high-tensile"]            = map{"paneling", "large-paneling", "framing", "girdering", "gearing", "fine-gearing",                          "wiring", "shielding", "shafting", "bolts", "rivets"},
-    ["corrosion-resistant"]     = map{"paneling", "large-paneling",                                                    "piping", "fine-piping",           "shielding",             "bolts", "rivets"},
-    ["lightweight"]             = map{"paneling", "large-paneling", "framing", "girdering",                                                                            "shafting"                   },
-    ["ductile"]                 = map{"paneling", "large-paneling", "framing", "girdering", "gearing", "fine-gearing",                          "wiring", "shielding"                               },
-    ["thermally-stable"]        = map{"paneling", "large-paneling", "framing", "girdering", "gearing", "fine-gearing", "piping", "fine-piping", "wiring", "shielding", "shafting", "bolts", "rivets"},
-    ["thermally-conductive"]    = map{                                                                                                          "wiring",              "shafting"                   },
-    ["radiation-resistant"]     = map{"paneling", "large-paneling",                                                                                       "shielding"                               },
-
+    [Machined_Part_Property.BASIC]                   = map{Machined_Part.PANELING, Machined_Part.LARGE_PANELING, Machined_Part.FRAMING, Machined_Part.GIRDERING, Machined_Part.GEARING, Machined_Part.FINE_GEARING, Machined_Part.PIPING, Machined_Part.FINE_PIPING, Machined_Part.WIRING, Machined_Part.SHIELDING, Machined_Part.SHAFTING, Machined_Part.BOLTS, Machined_Part.RIVETS},
+    [Machined_Part_Property.LOAD_BEARING]            = map{                                                      Machined_Part.FRAMING, Machined_Part.GIRDERING,                                                                                                                                                    Machined_Part.SHAFTING                                           },
+    [Machined_Part_Property.ELECTRICALLY_CONDUCTIVE] = map{                                                                                                                                                                                                          Machined_Part.WIRING                                                                                            },
+    [Machined_Part_Property.HIGH_TENSILE]            = map{Machined_Part.PANELING, Machined_Part.LARGE_PANELING, Machined_Part.FRAMING, Machined_Part.GIRDERING, Machined_Part.GEARING, Machined_Part.FINE_GEARING,                                                  Machined_Part.WIRING, Machined_Part.SHIELDING, Machined_Part.SHAFTING, Machined_Part.BOLTS, Machined_Part.RIVETS},
+    [Machined_Part_Property.CORROSION_RESISTANT]     = map{Machined_Part.PANELING, Machined_Part.LARGE_PANELING,                                                                                                    Machined_Part.PIPING, Machined_Part.FINE_PIPING,                       Machined_Part.SHIELDING,                         Machined_Part.BOLTS, Machined_Part.RIVETS},
+    [Machined_Part_Property.LIGHTWEIGHT]             = map{Machined_Part.PANELING, Machined_Part.LARGE_PANELING, Machined_Part.FRAMING, Machined_Part.GIRDERING,                                                                                                                                                    Machined_Part.SHAFTING                                           },
+    [Machined_Part_Property.DUCTILE]                 = map{Machined_Part.PANELING, Machined_Part.LARGE_PANELING, Machined_Part.FRAMING, Machined_Part.GIRDERING, Machined_Part.GEARING, Machined_Part.FINE_GEARING,                                                  Machined_Part.WIRING, Machined_Part.SHIELDING                                                                   },
+    [Machined_Part_Property.THERMALLY_STABLE]        = map{Machined_Part.PANELING, Machined_Part.LARGE_PANELING, Machined_Part.FRAMING, Machined_Part.GIRDERING, Machined_Part.GEARING, Machined_Part.FINE_GEARING, Machined_Part.PIPING, Machined_Part.FINE_PIPING, Machined_Part.WIRING, Machined_Part.SHIELDING, Machined_Part.SHAFTING, Machined_Part.BOLTS, Machined_Part.RIVETS},
+    [Machined_Part_Property.THERMALLY_CONDUCTIVE]    = map{                                                                                                                                                                                                          Machined_Part.WIRING,                          Machined_Part.SHAFTING                                           },
+    [Machined_Part_Property.RADIATION_RESISTANT]     = map{Machined_Part.PANELING, Machined_Part.LARGE_PANELING,                                                                                                                                                                           Machined_Part.SHIELDING                                                                   },
   }
 else
   property_machined_part_pairs = {
-    ["basic"]                   = map{"paneling", "framing", "gearing", "piping", "wiring", "shielding", "shafting", "bolts"},
-    ["load-bearing"]            = map{            "framing",                                             "shafting"         },
-    ["electrically-conductive"] = map{                                            "wiring"                                  },
-    ["high-tensile"]            = map{"paneling", "framing", "gearing",           "wiring", "shielding", "shafting", "bolts"},
-    ["corrosion-resistant"]     = map{"paneling",                       "piping",           "shielding",             "bolts"},
-    ["lightweight"]             = map{"paneling", "framing",                                             "shafting"         },
-    ["ductile"]                 = map{"paneling", "framing", "gearing",           "wiring", "shielding"                     },
-    ["thermally-stable"]        = map{"paneling", "framing", "gearing", "piping", "wiring", "shielding", "shafting", "bolts"},
-    ["thermally-conductive"]    = map{                                            "wiring",              "shafting"         },
-    ["radiation-resistant"]     = map{"paneling",                                           "shielding"                     }
+    [Machined_Part_Property.BASIC]                   = map{Machined_Part.PANELING, Machined_Part.FRAMING, Machined_Part.GEARING, Machined_Part.PIPING, Machined_Part.WIRING, Machined_Part.SHIELDING, Machined_Part.SHAFTING, Machined_Part.BOLTS},
+    [Machined_Part_Property.LOAD_BEARING]            = map{                        Machined_Part.FRAMING,                                                                                             Machined_Part.SHAFTING                     },
+    [Machined_Part_Property.ELECTRICALLY_CONDUCTIVE] = map{                                                                                            Machined_Part.WIRING                                                                      },
+    [Machined_Part_Property.HIGH_TENSILE]            = map{Machined_Part.PANELING, Machined_Part.FRAMING, Machined_Part.GEARING,                       Machined_Part.WIRING, Machined_Part.SHIELDING, Machined_Part.SHAFTING, Machined_Part.BOLTS},
+    [Machined_Part_Property.CORROSION_RESISTANT]     = map{Machined_Part.PANELING,                                               Machined_Part.PIPING,                       Machined_Part.SHIELDING,                         Machined_Part.BOLTS},
+    [Machined_Part_Property.LIGHTWEIGHT]             = map{Machined_Part.PANELING, Machined_Part.FRAMING,                                                                                             Machined_Part.SHAFTING                     },
+    [Machined_Part_Property.DUCTILE]                 = map{Machined_Part.PANELING, Machined_Part.FRAMING, Machined_Part.GEARING,                       Machined_Part.WIRING, Machined_Part.SHIELDING                                             },
+    [Machined_Part_Property.THERMALLY_STABLE]        = map{Machined_Part.PANELING, Machined_Part.FRAMING, Machined_Part.GEARING, Machined_Part.PIPING, Machined_Part.WIRING, Machined_Part.SHIELDING, Machined_Part.SHAFTING, Machined_Part.BOLTS},
+    [Machined_Part_Property.THERMALLY_CONDUCTIVE]    = map{                                                                                            Machined_Part.WIRING,                          Machined_Part.SHAFTING                     },
+    [Machined_Part_Property.RADIATION_RESISTANT]     = map{Machined_Part.PANELING,                                                                                           Machined_Part.SHIELDING                                             }
   }
 end
 
 -- duplicate the advancement properties over
-property_machined_part_pairs["heavy-load-bearing"] = property_machined_part_pairs["load-bearing"]
-property_machined_part_pairs["very-high-tensile"]  = property_machined_part_pairs["high-tensile"]
+property_machined_part_pairs[Machined_Part_Property.HEAVY_LOAD_BEARING] = property_machined_part_pairs[Machined_Part_Property.HEAVY_LOAD_BEARING]
+property_machined_part_pairs[Machined_Part_Property.VERY_HIGH_TENSILE]  = property_machined_part_pairs[Machined_Part_Property.VERY_HIGH_TENSILE]
 
 local stocks_precurors
 if advanced then -- stocks_precursors : [stock | stock that crafts it] {stock that crafts it, how many it takes, how many it makes}]
   stocks_precurors = {
-    ["angle"]         = {"sheet", 1, 1},
-    ["fine-gear"]     = {"sheet", 2, 1},
-    ["fine-pipe"]     = {"sheet", 3, 1},
-    ["sheet"]         = {"plate", 1, 2},
-    ["pipe"]          = {"plate", 1, 1},
-    ["girder"]        = {"plate", 4, 1},
-    ["gear"]          = {"plate", 2, 1},
-    ["square"]        = {"plate", 1, 2},
-    ["wire"]          = {"square", 1, 2}
+    [Stock.ANGLE]         = {Stock.SHEET, 1, 1},
+    [Stock.FINE_GEAR]     = {Stock.SHEET, 2, 1},
+    [Stock.FINE_PIPE]     = {Stock.SHEET, 3, 1},
+    [Stock.SHEET]         = {Stock.PLATE, 1, 2},
+    [Stock.PIPE]          = {Stock.PLATE, 1, 1},
+    [Stock.GIRDER]        = {Stock.PLATE, 4, 1},
+    [Stock.GEAR]          = {Stock.PLATE, 2, 1},
+    [Stock.SQUARE]        = {Stock.PLATE, 1, 2},
+    [Stock.WIRE]          = {Stock.SQUARE, 1, 2}
   }
 else
   stocks_precurors = {
-    ["square"]        = {"plate", 1, 2},
-    ["wire"]          = {"square", 1, 2}
+    [Stock.SQUARE]        = {Stock.PLATE, 1, 2},
+    [Stock.WIRE]          = {Stock.SQUARE, 1, 2}
   }
 end
 
 local machined_parts_precurors
 if advanced then -- machined_parts_precurors : [machined part | stock from which it's crafted] {stock from which it's crafted, how many it takes, how many it makes}]
   machined_parts_precurors = {
-    ["paneling"]        = {"sheet", 3, 1},
-    ["large-paneling"]  = {"sheet", 5, 1},
-    ["framing"]         = {"angle", 2, 1},
-    ["girdering"]       = {"girder", 1, 1},
-    ["gearing"]         = {"gear", 3, 1},
-    ["fine-gearing"]    = {"fine-gear", 2, 1},
-    ["piping"]          = {"pipe", 2, 1},
-    ["fine-piping"]     = {"fine-pipe", 1, 1},
-    ["wiring"]          = {"wire", 1, 1},
-    ["shielding"]       = {"plate", 6, 1},
-    ["shafting"]        = {"square", 1, 1},
-    ["bolts"]           = {"wire", 3, 1},
-    ["rivets"]          = {"wire", 4, 1}
+    [Machined_Part.PANELING]        = {Stock.SHEET, 3, 1},
+    [Machined_Part.LARGE_PANELING]  = {Stock.SHEET, 5, 1},
+    [Machined_Part.FRAMING]         = {Stock.ANGLE, 2, 1},
+    [Machined_Part.GIRDERING]       = {Stock.GIRDER, 1, 1},
+    [Machined_Part.GEARING]         = {Stock.GEAR, 3, 1},
+    [Machined_Part.FINE_GEARING]    = {Stock.FINE_GEAR, 2, 1},
+    [Machined_Part.PIPING]          = {Stock.PIPE, 2, 1},
+    [Machined_Part.FINE_PIPING]     = {Stock.FINE_PIPE, 1, 1},
+    [Machined_Part.WIRING]          = {Stock.WIRE, 1, 1},
+    [Machined_Part.SHIELDING]       = {Stock.PLATE, 6, 1},
+    [Machined_Part.SHAFTING]        = {Stock.SQUARE, 1, 1},
+    [Machined_Part.BOLTS]           = {Stock.WIRE, 3, 1},
+    [Machined_Part.RIVETS]          = {Stock.WIRE, 4, 1}
   }
 else
   machined_parts_precurors = {
-    ["paneling"]        = {"plate", 3, 1},
-    ["framing"]         = {"plate", 2, 1},
-    ["gearing"]         = {"plate", 3, 1},
-    ["piping"]          = {"plate", 2, 1},
-    ["shielding"]       = {"plate", 6, 1},
-    ["wiring"]          = {"square", 1, 1},
-    ["shafting"]        = {"square", 1, 1},
-    ["bolts"]           = {"wire", 4, 1}
+    [Machined_Part.PANELING]        = {Stock.PLATE, 3, 1},
+    [Machined_Part.FRAMING]         = {Stock.PLATE, 2, 1},
+    [Machined_Part.GEARING]         = {Stock.PLATE, 3, 1},
+    [Machined_Part.PIPING]          = {Stock.PLATE, 2, 1},
+    [Machined_Part.SHIELDING]       = {Stock.PLATE, 6, 1},
+    [Machined_Part.WIRING]          = {Stock.SQUARE, 1, 1},
+    [Machined_Part.SHAFTING]        = {Stock.SQUARE, 1, 1},
+    [Machined_Part.BOLTS]           = {Stock.WIRE, 4, 1}
   }
 end
 

--- a/intermediates/mw-data.lua
+++ b/intermediates/mw-data.lua
@@ -1,4 +1,9 @@
-require("enums")
+local enums = require("enums")
+local Resources = enums.Resources
+local Stock = enums.Stock
+local Machined_Part = enums.Machined_Part
+local Machined_Part_Property = enums.Machined_Part_Property
+local Minisembler = enums.Minisembler
 
 -- ********
 -- Settings

--- a/intermediates/mw-data.lua
+++ b/intermediates/mw-data.lua
@@ -230,7 +230,7 @@ local minisemblers_rendering_data = { -- Set up the minisembler rendering data
   },
 
   -- metal-bandsaw
-  ["metal-bandsaw"] = {
+  [Minisembler.METAL_BANDSAW] = {
     ["frame-count"] = 24,
     ["line-length"] = 5,
     ["hr"] = {
@@ -268,7 +268,7 @@ local minisemblers_rendering_data = { -- Set up the minisembler rendering data
   },
 
   -- welder
-  ["welder"] = {
+  [Minisembler.WELDER] = {
     ["frame-count"] = 24,
     ["line-length"] = 5,
     ["hr"] = {


### PR DESCRIPTION
This is to have only one place for resource names, and to have a single point of truth.
This will make autocomplete work for all resources in the "enums.lua" file.
I don't know if this helps with readability.

RoboticInfinite on Discord